### PR TITLE
Fix version conflicts caused by PR#327

### DIFF
--- a/Analogy.UnitTests/Analogy.UnitTests.csproj
+++ b/Analogy.UnitTests/Analogy.UnitTests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <ItemGroup>
-    <PackageReference Include="Analogy.LogViewer.Interfaces" Version="2.13.0" />
+    <PackageReference Include="Analogy.LogViewer.Interfaces" Version="2.14.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />

--- a/Analogy/Analogy.csproj
+++ b/Analogy/Analogy.csproj
@@ -66,10 +66,10 @@
 		<EmbeddedResource Remove="UserControls\UCLogsNonFloatable.resx" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Analogy.CommonUtilities" Version="1.5.1" />
-		<PackageReference Include="Analogy.LogViewer.Interfaces" Version="2.13.0" />
-		<PackageReference Include="Analogy.LogViewer.Template" Version="1.9.1" />
-		<PackageReference Include="Grpc.Core" Version="2.38.0" />
+		<PackageReference Include="Analogy.CommonUtilities" Version="1.5.2" />
+		<PackageReference Include="Analogy.LogViewer.Interfaces" Version="2.14.1" />
+		<PackageReference Include="Analogy.LogViewer.Template" Version="1.9.3" />
+		<PackageReference Include="Grpc.Core" Version="2.38.1" />
 		<PackageReference Include="Markdig" Version="0.25.0" />
 		<PackageReference Include="Markdig.SyntaxHighlighting" Version="1.1.7" />
 		<PackageReference Include="MessagePack" Version="2.2.85" />
@@ -129,7 +129,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Analogy.LogViewer.gRPC" Version="1.7.2">
+		<PackageReference Include="Analogy.LogViewer.gRPC" Version="1.7.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Analogy.LogViewer.gRPC from 1.7.2 to 1.7.4. [(PR#327)](https://github.com/LiorBanai/logviewer/pull/327).
Hope this fix can help you.

Best regards,
sucrose